### PR TITLE
Modified main/ota_updater.py to pass when antenna is not included in …

### DIFF
--- a/main/ota_updater.py
+++ b/main/ota_updater.py
@@ -65,8 +65,13 @@ class OTAUpdater:
             sta_if.active(True)
             #utime.sleep_ms(10000) # yield for network processes
 
-            #print('setting antenna')
-            sta_if.config(antenna=antenna)  # select antenna, 0=chip, 1=external
+            # on esp32 micropython sta_if.config(antenna.antenna) always causes an exception as antenna is not included
+            try:
+                #print('setting antenna')
+                sta_if.config(antenna=antenna)  # select antenna, 0=chip, 1=external
+            except:
+                pass
+
             #utime.sleep_ms(1000) # yield for network processes
 
             #print('connecting')


### PR DESCRIPTION
On esp32 micropython the call to sta_if.config(antenna=antenna) causes an exception and program stops as antenna is not in the esp32 port.

I know try...except...pass is not really clean but it works in this situation and the program completes and runs correctly on esp32.
